### PR TITLE
useragent: pass requested fields as map instead of list

### DIFF
--- a/libconnman-qt/useragent.cpp
+++ b/libconnman-qt/useragent.cpp
@@ -37,17 +37,7 @@ UserAgent::~UserAgent()
 void UserAgent::requestUserInput(ServiceRequestData* data)
 {
     m_req_data = data;
-    QVariantList fields;
-
-    foreach (const QString &key, data->fields.keys()) {
-        QVariantMap field;
-
-        field.insert("name", key);
-        field.insert("type", data->fields.value(key).toMap().value("Type"));
-        fields.append(QVariant(field));
-    }
-
-    emit userInputRequested(data->objectPath, fields);
+    emit userInputRequested(data->objectPath, data->fields);
 }
 
 void UserAgent::cancelUserInput()

--- a/libconnman-qt/useragent.h
+++ b/libconnman-qt/useragent.h
@@ -36,7 +36,7 @@ public:
     Q_INVOKABLE void sendUserReply(const QVariantMap &input);
 
 signals:
-    void userInputRequested(const QString &servicePath, const QVariantList &fields);
+    void userInputRequested(const QString &servicePath, const QVariantMap &fields);
     void userInputCanceled();
     void errorReported(const QString &error);
 


### PR DESCRIPTION
Revert the signature of userInputRequested signal to pass
requested fields as QVariantMap instead of QVariantList to avoid
additional manipulations in QML.
