### PR TITLE
make sure to emit signal after cache is updated.

### DIFF
--- a/libconnman-qt/sessionagent.cpp
+++ b/libconnman-qt/sessionagent.cpp
@@ -17,9 +17,6 @@ Example:
     SessionAgent *sessionAgent = new SessionAgent("/ConnmanSessionAgent",this);
     connect(sessionAgent,SIGNAL(settingsUpdated(QVariantMap)),
             this,SLOT(sessionSettingsUpdated(QVariantMap)));
-
-    sessionAgent->registerSession(); // you MUST call this!
-
     sessionAgent->setAllowedBearers(QStringList() << "wifi" << "ethernet" << "cellular");
     sessionAgent->requestConnect();
 


### PR DESCRIPTION
serviceChanged, serviceAdded and serviceRemoved are better emitted after the property cache is updated.
