### PR TITLE
Add servicePath to UserAgent::errorReported() signal

### DIFF
--- a/libconnman-qt/useragent.cpp
+++ b/libconnman-qt/useragent.cpp
@@ -45,9 +45,9 @@ void UserAgent::cancelUserInput()
     emit userInputCanceled();
 }
 
-void UserAgent::reportError(const QString &error)
+void UserAgent::reportError(const QString &servicePath, const QString &error)
 {
-    emit errorReported(error);
+    emit errorReported(servicePath, error);
 }
 
 void UserAgent::sendUserReply(const QVariantMap &input)
@@ -168,8 +168,7 @@ void AgentAdaptor::Release()
 
 void AgentAdaptor::ReportError(const QDBusObjectPath &service_path, const QString &error)
 {
-    Q_UNUSED(service_path)
-    m_userAgent->reportError(error);
+    m_userAgent->reportError(service_path.path(), error);
 }
 
 void AgentAdaptor::RequestBrowser(const QDBusObjectPath &service_path, const QString &url)

--- a/libconnman-qt/useragent.h
+++ b/libconnman-qt/useragent.h
@@ -53,7 +53,7 @@ public slots:
 signals:
     void userInputRequested(const QString &servicePath, const QVariantMap &fields);
     void userInputCanceled();
-    void errorReported(const QString &error);
+    void errorReported(const QString &servicePath, const QString &error);
 
     void userConnectRequested(const QDBusMessage &message);
     void connectionRequest();
@@ -65,7 +65,7 @@ private slots:
 private:
     void requestUserInput(ServiceRequestData* data);
     void cancelUserInput();
-    void reportError(const QString &error);
+    void reportError(const QString &servicePath, const QString &error);
     void requestConnect(const QDBusMessage &msg);
 
     ServiceRequestData* m_req_data;

--- a/tests/ut_agent.cpp
+++ b/tests/ut_agent.cpp
@@ -215,9 +215,10 @@ void UtAgent::testReportError()
 {
     QDBusInterface manager("net.connman", "/", "net.connman.Manager", bus());
 
-    SignalSpy errorReportedSpy(m_userAgent, SIGNAL(errorReported(QString)));
+    SignalSpy errorReportedSpy(m_userAgent, SIGNAL(errorReported(QString, QString)));
 
-    const QDBusObjectPath injectedService = QDBusObjectPath("/foo");
+    const QString injectedServicePath = "/foo";
+    const QDBusObjectPath injectedService = QDBusObjectPath(injectedServicePath);
     const QString injectedError = "foo-error-foo";
 
     QDBusPendingReply<> reply = manager.asyncCall("mock_reportError",
@@ -227,8 +228,8 @@ void UtAgent::testReportError()
     QVERIFY(waitForSignal(&errorReportedSpy));
 
     QCOMPARE(errorReportedSpy.count(), 1);
-    // 'service' field is not emitted
-    QCOMPARE(errorReportedSpy.at(0).at(0).toString(), injectedError);
+    QCOMPARE(errorReportedSpy.at(0).at(0).toString(), injectedServicePath);
+    QCOMPARE(errorReportedSpy.at(0).at(1).toString(), injectedError);
 
     reply.waitForFinished();
     QVERIFY(reply.isValid());


### PR DESCRIPTION
This change makes agent API of the wrapper closer to connman's API
and is required to make UI less stateful in order to pinpoint
erroneous network.
