### PR TITLE
[connman-qt] Expose functionality required to reset counters.

### DIFF
--- a/libconnman-qt/networkservice.cpp
+++ b/libconnman-qt/networkservice.cpp
@@ -247,6 +247,11 @@ void NetworkService::setProxyConfig(const QVariantMap &proxy)
     m_service->SetProperty(ProxyConfig, QDBusVariant(QVariant(adaptToConnmanProperties(proxy))));
 }
 
+void NetworkService::resetCounters()
+{
+    m_service->ResetCounters();
+}
+
 void NetworkService::handleConnectReply(QDBusPendingCallWatcher *call)
 {
     Q_ASSERT(call);

--- a/libconnman-qt/networkservice.h
+++ b/libconnman-qt/networkservice.h
@@ -110,6 +110,8 @@ public slots:
     void setDomainsConfig(const QStringList &domains);
     void setProxyConfig(const QVariantMap &proxy);
 
+    void resetCounters();
+
 private:
     NetConnmanServiceInterface *m_service;
     QString m_path;


### PR DESCRIPTION
Add NetworkService::resetCounters() function.
