### PR TITLE
[connman-qt] Ensure errors are always reported when connecting.

### DIFF
--- a/libconnman-qt/networkservice.cpp
+++ b/libconnman-qt/networkservice.cpp
@@ -184,6 +184,11 @@ bool NetworkService::roaming() const
 
 void NetworkService::requestConnect()
 {
+    // If the service is in the failure state clear the Error property so that we get notified of
+    // errors on subsequent connection attempts.
+    if (state() == QLatin1String("failure"))
+        m_service->ClearProperty(QLatin1String("Error"));
+
     // increase reply timeout when connecting
     int timeout = CONNECT_TIMEOUT_FAVORITE;
     int old_timeout = m_service->timeout();


### PR DESCRIPTION
Error notifications are not sent on subsequent connection attempts if
the service is in the failure state. Clear the Error property if the
service is in the failure state prior to attempting to connect.
