### PR TITLE
revert async change

### DIFF
--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -124,8 +124,6 @@ private slots:
     void technologyAdded(const QDBusObjectPath &technology, const QVariantMap &properties);
     void technologyRemoved(const QDBusObjectPath &technology);
 
-    void getPropertiesReply(QDBusPendingCallWatcher *call);
-    void setOfflineModeFinished(QDBusPendingCallWatcher *call);
 
 private:
     Q_DISABLE_COPY(NetworkManager);


### PR DESCRIPTION
This reverts commit cc2ad85df46560eee7e4b5b5b448f4ad41264159.

Properties for qml need to be available immediately. The only way
to do this is waitForFinished.
