### PR TITLE
Expose getTechnology() to QML

### DIFF
--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -48,7 +48,7 @@ public:
 
     bool isAvailable() const;
 
-    NetworkTechnology* getTechnology(const QString &type) const;
+    Q_INVOKABLE NetworkTechnology* getTechnology(const QString &type) const;
     const QVector<NetworkTechnology *> getTechnologies() const;
     const QVector<NetworkService*> getServices(const QString &tech = "") const;
 


### PR DESCRIPTION
It's useful in situations where all the technologies are listed at
once from technologiesList() where we only have the technology name
and need a NetworkTechnology object.
