### PR TITLE
Get a specific NetworkService

### DIFF
--- a/plugin/technologymodel.cpp
+++ b/plugin/technologymodel.cpp
@@ -178,6 +178,13 @@ void TechnologyModel::managerAvailabilityChanged(bool available)
     emit availabilityChanged(available);
 }
 
+NetworkService *TechnologyModel::get(int index) const
+{
+    if (index < 0 || index > m_services.count())
+        return 0;
+    return m_services.value(index);
+}
+
 int TechnologyModel::indexOf(const QString &dbusObjectPath) const
 {
     int idx(-1);

--- a/plugin/technologymodel.h
+++ b/plugin/technologymodel.h
@@ -49,6 +49,8 @@ public:
 
     Q_INVOKABLE int indexOf(const QString &dbusObjectPath) const;
 
+    Q_INVOKABLE NetworkService *get(int index) const;
+
 public slots:
     void setPowered(const bool &powered);
     void requestScan() const;


### PR DESCRIPTION
This method returns a specific NetworkService object and is available
from QML.
