### PR TITLE
Replace qDebug() with pr_dbg()

### DIFF
--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -61,7 +61,7 @@ NetworkManager::NetworkManager(QObject* parent)
     if(m_available)
         connectToConnman();
     else
-        qDebug() << "connman not AVAILABLE";
+        pr_dbg() << "connman not AVAILABLE";
 }
 
 NetworkManager::~NetworkManager()

--- a/libconnman-qt/networkservice.cpp
+++ b/libconnman-qt/networkservice.cpp
@@ -348,7 +348,7 @@ void NetworkService::setPath(const QString &path)
             QDBusPendingReply<QVariantMap> reply = m_service->GetProperties();
             reply.waitForFinished();
             if (reply.isError()) {
-                qDebug() << Q_FUNC_INFO << reply.error().message();
+	        pr_dbg() << reply.error().message();
             } else {
                 m_propertiesCache = reply.value();
             }

--- a/libconnman-qt/sessionagent.cpp
+++ b/libconnman-qt/sessionagent.cpp
@@ -50,7 +50,7 @@ void SessionAgent::setAllowedBearers(const QStringList &bearers)
     // hope this is not a lengthy task
     reply.waitForFinished();
     if (reply.isError()) {
-        qDebug() << Q_FUNC_INFO << reply.error();
+        pr_dbg() << reply.error();
     }
 
 }
@@ -74,13 +74,13 @@ void SessionAgent::createSession()
             new SessionNotificationAdaptor(this);
             QDBusConnection::systemBus().unregisterObject(agentPath);
             if (!QDBusConnection::systemBus().registerObject(agentPath, this)) {
-                qDebug() << "Could not register agent object";
+	        pr_dbg() << "Could not register agent object";
             }
         } else {
-            qDebug() << "agentPath is not valid" << agentPath;
+            pr_dbg() << "agentPath is not valid" << agentPath;
         }
     } else {
-        qDebug() << Q_FUNC_INFO << "manager not valid";
+        pr_dbg() << "manager not valid";
     }
 }
 
@@ -120,7 +120,7 @@ void SessionAgent::onConnectFinished(QDBusPendingCallWatcher *call)
 {
   QDBusPendingReply<> reply = *call;
   if (reply.isError())
-    qDebug() << reply.error().message();
+    pr_dbg() << reply.error().message();
 
   call->deleteLater();
 }

--- a/libconnman-qt/useragent.cpp
+++ b/libconnman-qt/useragent.cpp
@@ -78,7 +78,7 @@ void UserAgent::requestTimeout()
     setConnectionRequestType("Clear");
     QDBusMessage &reply = requestMessage;
     if (!QDBusConnection::systemBus().send(reply)) {
-        qDebug() << "Could not queue message";
+        pr_dbg() << "Could not queue message";
     }
 }
 
@@ -137,7 +137,7 @@ void UserAgent::requestConnect(const QDBusMessage &msg)
     QDBusMessage error = msg.createReply(arguments);
 
     if (!QDBusConnection::systemBus().send(error)) {
-        qDebug() << "Could not queue message";
+        pr_dbg() << "Could not queue message";
     }
 
     if (connectionRequestType() == "Suppress") {


### PR DESCRIPTION
In case the few qDebug() present in the code weren't intentional, here is a quick patch that replace them with pr_dbg(), it helps libconnman-qt's users with troubleshooting.
