### PR TITLE
[libconnman-qt] Fix crash when no services are available

### DIFF
--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -357,7 +357,7 @@ void NetworkManager::updateSavedServices(const ConnmanObjectList &changed)
 
 void NetworkManager::updateDefaultRoute(NetworkService* defaultRoute)
 {
-    if (defaultRoute->state() != "online") {
+    if (defaultRoute && defaultRoute->state() != "online") {
         NetworkService *tempSer;
         tempSer = new NetworkService("/",QVariantMap(),this);
         m_defaultRoute = tempSer;


### PR DESCRIPTION
Bug introduced by ed9d0692bee7024fa964810cd1c6cbdbe420cb80
