### PR TITLE
[connman-qt] Remove saved services that are not currently in range.

### DIFF
--- a/libconnman-qt/connman_manager.xml
+++ b/libconnman-qt/connman_manager.xml
@@ -27,6 +27,10 @@
         <annotation name="org.qtproject.QtDBus.QtTypeName.Out0" value="ConnmanObjectList"/>
     </method>
 
+    <method name="RemoveSavedService" tp:name-for-bindings="Remove_Saved_Services">
+        <arg name="identifier" type="s" direction="in"/>
+    </method>
+
     <method name="RegisterAgent" tp:name-for-bindings="Register_Agent">
         <arg name="path" type="o"/>
     </method>

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -52,6 +52,7 @@ public:
     const QVector<NetworkTechnology *> getTechnologies() const;
     const QVector<NetworkService*> getServices(const QString &tech = "") const;
     const QVector<NetworkService*> getSavedServices(const QString &tech = "") const;
+    void removeSavedService(const QString &identifier) const;
 
     Q_INVOKABLE QStringList servicesList(const QString &tech);
     Q_INVOKABLE QStringList technologiesList();

--- a/libconnman-qt/networkservice.h
+++ b/libconnman-qt/networkservice.h
@@ -150,6 +150,7 @@ private:
 private slots:
     void updateProperty(const QString &name, const QDBusVariant &value);
     void handleConnectReply(QDBusPendingCallWatcher *call);
+    void handleRemoveReply(QDBusPendingCallWatcher *watcher);
 
 private:
     Q_DISABLE_COPY(NetworkService);


### PR DESCRIPTION
If net.connman.Service.Remove fails, try
net.connman.Manager.RemoveSavedService instead.
