### PR TITLE
[connman-qt] Reuse invalid default route NetworkService.

### DIFF
--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -40,6 +40,7 @@ NetworkManager::NetworkManager(QObject* parent)
   : QObject(parent),
     m_manager(NULL),
     m_defaultRoute(NULL),
+    m_invalidDefaultRoute(NULL),
     watcher(NULL),
     m_available(false)
 {
@@ -356,9 +357,10 @@ void NetworkManager::updateSavedServices(const ConnmanObjectList &changed)
 void NetworkManager::updateDefaultRoute(NetworkService* defaultRoute)
 {
     if (!defaultRoute || defaultRoute->state() != "online") {
-        NetworkService *tempSer;
-        tempSer = new NetworkService("/",QVariantMap(),this);
-        m_defaultRoute = tempSer;
+        if (!m_invalidDefaultRoute)
+            m_invalidDefaultRoute = new NetworkService("/", QVariantMap(), this);
+
+        m_defaultRoute = m_invalidDefaultRoute;
         emit defaultRouteChanged(m_defaultRoute);
         return;
     }

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -108,6 +108,9 @@ private:
     /* This variable is used just to send signal if changed */
     NetworkService* m_defaultRoute;
 
+    /* Invalid default route service for use when there is no default route */
+    NetworkService *m_invalidDefaultRoute;
+
     QDBusServiceWatcher *watcher;
 
     static const QString State;


### PR DESCRIPTION
Fix memory leak when default route is unset.
