### PR TITLE
[connman-qt] Set idle state for saved networks when they are no longer a...

### DIFF
--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -302,6 +302,7 @@ void NetworkManager::updateServices(const ConnmanObjectList &changed, const QLis
                     // Update the strength value to zero, so we know it isn't visible
                     QVariantMap properties;
                     properties.insert(QString::fromLatin1("Strength"), QVariant(static_cast<quint32>(0)));
+                    properties.insert(QStringLiteral("State"), QStringLiteral("idle"));
                     service->updateProperties(properties);
                 } else {
                     service->deleteLater();


### PR DESCRIPTION
...vailable.

When going out of range or when powering off WLAN the network service
maybe left with the State property set to connecting, etc. Always set
it to idle when the network service is being reused because it is a
saved network.
