### PR TITLE
[connman-qt] Add ResetCountersForType method.

### DIFF
--- a/libconnman-qt/connman_manager.xml
+++ b/libconnman-qt/connman_manager.xml
@@ -49,6 +49,10 @@
         <arg name="path" type="o"/>
     </method>
 
+    <method name="ResetCounters" tp:name-for-bindings="Reset_Counters">
+        <arg name="type" type="s"/>
+    </method>
+
     <method name="CreateSession" tp:name-for-bindings="Create_Session">
         <arg name="settings" type="a{sv}"/>
         <annotation name="org.qtproject.QtDBus.QtTypeName.In0" value="QVariantMap"/>

--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -573,6 +573,11 @@ bool NetworkManager::sessionMode() const
     return m_propertiesCache[SessionMode].toBool();
 }
 
+void NetworkManager::resetCountersForType(const QString &type)
+{
+    m_manager->ResetCounters(type);
+}
+
 QStringList NetworkManager::servicesList(const QString &tech)
 {
     QStringList services;

--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -66,6 +66,8 @@ public:
 
     bool sessionMode() const;
 
+    Q_INVOKABLE void resetCountersForType(const QString &type);
+
 public Q_SLOTS:
     void setOfflineMode(const bool &offlineMode);
     void registerAgent(const QString &path);


### PR DESCRIPTION
Add a method to reset all counters for the specified type of network
service.

Depends on https://github.com/mer-packages/connman/pull/12
