### PR TITLE
[connman-qt] Add properties to selectively enable services and technolog...

### DIFF
--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -42,6 +42,9 @@ class NetworkManager : public QObject
 
     Q_PROPERTY(bool sessionMode READ sessionMode WRITE setSessionMode NOTIFY sessionModeChanged)
 
+    Q_PROPERTY(bool servicesEnabled READ servicesEnabled WRITE setServicesEnabled NOTIFY servicesEnabledChanged)
+    Q_PROPERTY(bool technologiesEnabled READ technologiesEnabled WRITE setTechnologiesEnabled NOTIFY technologiesEnabledChanged)
+
 public:
     NetworkManager(QObject* parent=0);
     virtual ~NetworkManager();
@@ -65,6 +68,12 @@ public:
     NetworkService* defaultRoute() const;
 
     bool sessionMode() const;
+
+    bool servicesEnabled() const;
+    void setServicesEnabled(bool enabled);
+
+    bool technologiesEnabled() const;
+    void setTechnologiesEnabled(bool enabled);
 
     Q_INVOKABLE void resetCountersForType(const QString &type);
 
@@ -92,6 +101,9 @@ Q_SIGNALS:
     void servicesListChanged(const QStringList &list);
     void serviceAdded(const QString &servicePath);
     void serviceRemoved(const QString &servicePath);
+
+    void servicesEnabledChanged();
+    void technologiesEnabledChanged();
 
 private:
     NetConnmanManagerInterface *m_manager;
@@ -121,13 +133,18 @@ private:
 
     bool m_available;
 
+    bool m_servicesEnabled;
+    bool m_technologiesEnabled;
+
     void updateDefaultRoute();
 
 private Q_SLOTS:
     void connectToConnman(QString = "");
     void disconnectFromConnman(QString = "");
     void connmanUnregistered(QString = "");
+    void disconnectTechnologies();
     void setupTechnologies();
+    void disconnectServices();
     void setupServices();
     void propertyChanged(const QString &name, const QDBusVariant &value);
     void updateServices(const ConnmanObjectList &changed, const QList<QDBusObjectPath> &removed);


### PR DESCRIPTION
...y updates.

Updating services and technologies is unnecessary for some use cases
and states. Such as when an application is only interested in the
offlineMode or state properties or when the functionality is not being
actively used by the user.

Two properties are added servicesEnabled and technologiesEnabled, both
default to true. When servicesEnabled is false NetworkManager will
report that there are no network services available. When
technologiesEnabled is false NetworkManager will report that there are
no technologies available.

In many applications a single global shared instance of NetworkManager
is created. When using these properties applications should ensure that
the values are appropriate for all users of the NetworkManager
instance.
