### PR TITLE
[libconnman-qt] Only emit NetworkService signals when properties change.

### DIFF
--- a/libconnman-qt/networkservice.cpp
+++ b/libconnman-qt/networkservice.cpp
@@ -358,6 +358,9 @@ void NetworkService::handleRemoveReply(QDBusPendingCallWatcher *watcher)
 
 void NetworkService::emitPropertyChange(const QString &name, const QVariant &value)
 {
+    if (m_propertiesCache.value(name) == value)
+        return;
+
     m_propertiesCache[name] = value;
 
     if (name == Name) {


### PR DESCRIPTION
Applications rely on the property changed signals only being emitted
when the property value actually changes.
