### PR TITLE
[connman-qt] Always return a network service object as the default route...

### DIFF
--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -40,7 +40,7 @@ NetworkManager::NetworkManager(QObject* parent)
   : QObject(parent),
     m_manager(NULL),
     m_defaultRoute(NULL),
-    m_invalidDefaultRoute(NULL),
+    m_invalidDefaultRoute(new NetworkService("/", QVariantMap(), this)),
     watcher(NULL),
     m_available(false),
     m_servicesEnabled(true),
@@ -438,8 +438,6 @@ void NetworkManager::updateDefaultRoute()
             }
         }
     }
-    if (!m_invalidDefaultRoute)
-        m_invalidDefaultRoute = new NetworkService("/", QVariantMap(), this);
 
     m_defaultRoute = m_invalidDefaultRoute;
     Q_EMIT defaultRouteChanged(m_defaultRoute);


### PR DESCRIPTION
....

Always return a valid object, representing an invalid network service,
when no default route is set. Simplifies the API as no default route
set was represented as either a null network service or a valid network
service object with the state property set as an empty string.
