### PR TITLE
[libconnman-qt] Remove deleted network services from TechnologyModel

### DIFF
--- a/plugin/technologymodel.h
+++ b/plugin/technologymodel.h
@@ -95,6 +95,7 @@ private Q_SLOTS:
     void changedConnected(bool);
     void finishedScan();
     void refresh();
+    void networkServiceDestroyed(QObject *);
 };
 
 #endif // TECHNOLOGYMODEL_H


### PR DESCRIPTION
In some cases, TechnologyModel would not remove the NetworkServices
before they were destroyed, risking stale pointers in m_services.
