### PR TITLE
[libconnman-qt] Fix service list update.

### DIFF
--- a/plugin/technologymodel.cpp
+++ b/plugin/technologymodel.cpp
@@ -321,10 +321,13 @@ void TechnologyModel::updateServiceList()
             endMoveRows();
         }
     }
+    // After loop:
+    // m_services contains [new_services, old_services \ new_services]
 
-    if (num_old > num_new) {
-        beginRemoveRows(QModelIndex(), num_new, num_old - 1);
-        m_services.remove(num_new, num_old - num_new);
+    int num_union = m_services.count();
+    if (num_union > num_new) {
+        beginRemoveRows(QModelIndex(), num_new, num_union - 1);
+        m_services.remove(num_new, num_union - num_new);
         endRemoveRows();
     }
 


### PR DESCRIPTION
Previously, the loop would just prepend the new services
to m_services, without removing old services, if num_old <= num_new.

Ie. old: [a,b,c] new: [c,d,e] would become [c,d,e,a,b]
