### PR TITLE
[connman-qt] Fix signal emission on property changes.

### DIFF
--- a/libconnman-qt/networkservice.h
+++ b/libconnman-qt/networkservice.h
@@ -150,11 +150,14 @@ private:
 private Q_SLOTS:
     void updateProperty(const QString &name, const QDBusVariant &value);
     void emitPropertyChange(const QString &name, const QVariant &value);
+    void getPropertiesFinished(QDBusPendingCallWatcher *call);
 
     void handleConnectReply(QDBusPendingCallWatcher *call);
     void handleRemoveReply(QDBusPendingCallWatcher *watcher);
 
 private:
+    void resetProperties();
+
     Q_DISABLE_COPY(NetworkService);
 };
 


### PR DESCRIPTION
This fixes two issues. Setting the path on a network service
does not emit property changed signals. As a consequence that stored
state of the isConnected property may not relect its true value. Emits
the connected changed signal when the service goes offline for the
first time.
