### PR TITLE
[connman-qt] Fix missing items in saved services model.

### DIFF
--- a/libconnman-qt/networkservice.h
+++ b/libconnman-qt/networkservice.h
@@ -159,6 +159,7 @@ private Q_SLOTS:
 
 private:
     void resetProperties();
+    void reconnectServiceInterface();
 
     Q_DISABLE_COPY(NetworkService);
 };

--- a/plugin/savedservicemodel.cpp
+++ b/plugin/savedservicemodel.cpp
@@ -67,6 +67,9 @@ void SavedServiceModel::setName(const QString &name)
         return;
     }
 
+    m_techname = name;
+    Q_EMIT nameChanged(m_techname);
+
     QStringList netTypes = m_manager->technologiesList();
     if (!netTypes.contains(name)) {
         qDebug() << name <<  "is not a known technology name:" << netTypes;


### PR DESCRIPTION
Make use of the provided properties passed to the NetworkService
constructor without initiating an addition properties request or
emitting property changed signals.
