### PR TITLE
[connman-qt] Fix emission of servicesChanged() signal.

### DIFF
--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -426,13 +426,13 @@ void NetworkManager::getServicesFinished(QDBusPendingCallWatcher *watcher)
             service = new NetworkService(servicePath, object.properties, this);
             connect(service,SIGNAL(connectedChanged(bool)),this,SLOT(updateDefaultRoute()));
             m_servicesCache.insert(servicePath, service);
-            Q_EMIT servicesChanged();
         }
 
         m_servicesOrder.append(service);
     }
 
     updateDefaultRoute();
+    Q_EMIT servicesChanged();
     Q_EMIT servicesListChanged(m_servicesCache.keys());
 }
 


### PR DESCRIPTION
The servicesChanged() signal was being emitted after each new service
was added to the services cache, but before being appended to the
services order list. Slots directly connected to this signal that
call functions that rely on the services order fail to get the changes
as the services order has not been updated yet.

Only emit the serviceschanged() signal after all changed services have
been processed.
