### PR TITLE
[connman-qt] Don't start scanning if in tethering mode.

### DIFF
--- a/plugin/technologymodel.cpp
+++ b/plugin/technologymodel.cpp
@@ -214,7 +214,7 @@ void TechnologyModel::setChangesInhibited(bool b)
 
 void TechnologyModel::requestScan()
 {
-    if (m_tech) {
+    if (m_tech && !m_tech->tethering()) {
         m_tech->scan();
         m_scanning = true;
         Q_EMIT scanningChanged(m_scanning);


### PR DESCRIPTION
The scan will fail to find any network services when in tethering
mode, there is no point in even starting the scan.
