### PR TITLE
[connman-qt] Don't hard code library version in project file.

### DIFF
--- a/libconnman-qt/libconnman-qt.pro
+++ b/libconnman-qt/libconnman-qt.pro
@@ -1,9 +1,10 @@
 TEMPLATE     = lib
-VERSION      = 1.0.68
 CONFIG      += qt debug
 CONFIG      += create_pc create_prl
 QT          += core dbus network
 QT -= gui
+
+isEmpty(VERSION):warning(VERSION unset. Run qmake with \'qmake VERSION=x.y.z\')
 
 isEmpty(PREFIX) {
   PREFIX=/usr

--- a/rpm/connman-qt.spec
+++ b/rpm/connman-qt.spec
@@ -73,7 +73,7 @@ export PATH=$PATH:/usr/lib/qt4/bin
 qmake install_prefix=/usr
 # << build pre
 
-%qmake
+%qmake -r VERSION=%{version}
 
 make %{?_smp_mflags}
 

--- a/rpm/connman-qt5.spec
+++ b/rpm/connman-qt5.spec
@@ -59,7 +59,7 @@ applications using libconnman-qt
 # >> build pre
 # << build pre
 
-%qmake5
+%qmake5 -r VERSION=%{version}
 
 make %{?_smp_mflags}
 


### PR DESCRIPTION
The library version number for libconnman-qt is stored in three
seperate locations: the project file and the two RPM spec files. Remove
the library version number from the project file and instead pass it in
when qmake is called during build.
