### PR TITLE
[connman-qt] Improve counter registration/unregistration behaviour.

### DIFF
--- a/libconnman-qt/counter.h
+++ b/libconnman-qt/counter.h
@@ -65,7 +65,10 @@ Q_SIGNALS:
     void accuracyChanged(quint32 accuracy);
     void intervalChanged(quint32 interval);
     void runningChanged(bool running);
-    
+
+private Q_SLOTS:
+    void updateCounterAgent();
+
 private:
        NetworkManager* m_manager;
 
@@ -85,14 +88,11 @@ private:
        bool roamingEnabled;
        quint32 currentInterval;
        quint32 currentAccuracy;
-       bool isRunning;
 
-       void reRegister();
        QString counterPath;
        bool shouldBeRunning;
 
-private Q_SLOTS:
-       void updateMgrAvailability(bool);
+       bool registered;
 };
 
 class CounterAdaptor : public QDBusAbstractAdaptor


### PR DESCRIPTION
During initial counter construction and property assignment the data
counter is registered and unregistered from Connman many times. Fixed
by keeping track of the registration status of the counter and only
registering or unregistering if necessary.
