### PR TITLE
[connman-qt] Revert scanResultsReady-commit as it does not _work_ like it is supposed to

### DIFF
--- a/plugin/technologymodel.cpp
+++ b/plugin/technologymodel.cpp
@@ -17,8 +17,7 @@ TechnologyModel::TechnologyModel(QAbstractListModel* parent)
     m_tech(NULL),
     m_scanning(false),
     m_changesInhibited(false),
-    m_uneffectedChanges(false),
-    m_scanResultsReady(false)
+    m_uneffectedChanges(false)
 {
     m_manager = NetworkManagerFactory::createInstance();
 
@@ -105,11 +104,6 @@ bool TechnologyModel::isPowered() const
 bool TechnologyModel::isScanning() const
 {
     return m_scanning;
-}
-
-bool TechnologyModel::isScanResultsReady() const
-{
-    return m_scanResultsReady;
 }
 
 bool TechnologyModel::changesInhibited() const
@@ -304,9 +298,6 @@ void TechnologyModel::updateServiceList()
 
     if (num_new != num_old)
         Q_EMIT countChanged();
-
-    m_scanResultsReady = true;
-    Q_EMIT scanResultsReadyChanged(m_scanResultsReady);
 }
 
 void TechnologyModel::changedPower(bool b)
@@ -335,9 +326,6 @@ void TechnologyModel::finishedScan()
     NetworkTechnology *tech = qobject_cast<NetworkTechnology *>(sender());
     if (tech->type() != m_tech->type())
         return;
-
-    m_scanResultsReady = false;
-    Q_EMIT scanResultsReadyChanged(m_scanResultsReady);
 
     Q_EMIT scanRequestFinished();
 

--- a/plugin/technologymodel.h
+++ b/plugin/technologymodel.h
@@ -33,7 +33,6 @@ class TechnologyModel : public QAbstractListModel
     Q_PROPERTY(bool scanning READ isScanning NOTIFY scanningChanged)
     Q_PROPERTY(bool changesInhibited READ changesInhibited WRITE setChangesInhibited NOTIFY changesInhibitedChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
-    Q_PROPERTY(bool scanResultsReady READ isScanResultsReady NOTIFY scanResultsReadyChanged)
 
 public:
     enum ItemRoles {
@@ -53,7 +52,6 @@ public:
     bool isConnected() const;
     bool isPowered() const;
     bool isScanning() const;
-    bool isScanResultsReady() const;
     bool changesInhibited() const;
 
     void setName(const QString &name);
@@ -76,7 +74,6 @@ Q_SIGNALS:
     void changesInhibitedChanged(const bool &changesInhibited);
     void technologiesChanged();
     void countChanged();
-    void scanResultsReadyChanged(const bool &scanResultsReady);
 
     void scanRequestFinished();
 
@@ -88,7 +85,6 @@ private:
     bool m_scanning;
     bool m_changesInhibited;
     bool m_uneffectedChanges;
-    bool m_scanResultsReady;
     QHash<int, QByteArray> roleNames() const;
     void doUpdateTechnologies();
 


### PR DESCRIPTION
This reverts commit eb97acfc9900249ae251e3c844795d70432d6e96.
