### PR TITLE
Use QString() instead of "" in headers.

### DIFF
--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -53,8 +53,8 @@ public:
 
     Q_INVOKABLE NetworkTechnology* getTechnology(const QString &type) const;
     const QVector<NetworkTechnology *> getTechnologies() const;
-    const QVector<NetworkService*> getServices(const QString &tech = "") const;
-    const QVector<NetworkService*> getSavedServices(const QString &tech = "") const;
+    const QVector<NetworkService*> getServices(const QString &tech = QString()) const;
+    const QVector<NetworkService*> getSavedServices(const QString &tech = QString()) const;
     void removeSavedService(const QString &identifier) const;
 
     Q_INVOKABLE QStringList servicesList(const QString &tech);
@@ -141,9 +141,9 @@ private:
 
 
 private Q_SLOTS:
-    void connectToConnman(QString = "");
-    void disconnectFromConnman(QString = "");
-    void connmanUnregistered(QString = "");
+    void connectToConnman(QString = QString());
+    void disconnectFromConnman(QString = QString());
+    void connmanUnregistered(QString = QString());
     void disconnectTechnologies();
     void setupTechnologies();
     void disconnectServices();


### PR DESCRIPTION
Besides QString() being the right way to initialize an empty string, using "" breaks every build which features QT_NO_CAST_FROM_ASCII. This patch fixes this issue.