### PR TITLE
[connman-qt] Remove debug message about unknown technology

### DIFF
--- a/libconnman-qt/networkmanager.cpp
+++ b/libconnman-qt/networkmanager.cpp
@@ -530,12 +530,7 @@ NetworkService* NetworkManager::defaultRoute() const
 
 NetworkTechnology* NetworkManager::getTechnology(const QString &type) const
 {
-    if (m_technologiesCache.contains(type))
-        return m_technologiesCache.value(type);
-    else {
-        qDebug() << "Technology " << type << " doesn't exist";
-        return NULL;
-    }
+    return m_technologiesCache.value(type);
 }
 
 const QVector<NetworkTechnology *> NetworkManager::getTechnologies() const


### PR DESCRIPTION
This message can be misleading as it is frequently displayed
referencing known technologies. Due to the use of asynchronous DBus
calls the NetworkManager::getTechnology() function may be called prior
to the available technology list being populated. This happens, for
example, when the name property of the TechnologyModel is set during
construction.