### PR TITLE
[connman-qt] Ensure NetworkService properties are updated

### DIFF
--- a/libconnman-qt/networkservice.cpp
+++ b/libconnman-qt/networkservice.cpp
@@ -475,7 +475,16 @@ void NetworkService::reconnectServiceInterface()
     connect(m_service, SIGNAL(PropertyChanged(QString,QDBusVariant)),
             this, SLOT(updateProperty(QString,QDBusVariant)));
 
-    QTimer::singleShot(500,this,SIGNAL(propertiesReady()));
+    if (!m_service || !m_service->isValid())
+        return;
+
+    if (path != QStringLiteral("/")) {
+        QDBusPendingReply<QVariantMap> reply = m_service->GetProperties();
+        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
+
+        connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)),
+                this, SLOT(getPropertiesFinished(QDBusPendingCallWatcher*)));
+    }
 }
 
 void NetworkService::emitPropertyChange(const QString &name, const QVariant &value)
@@ -586,15 +595,6 @@ void NetworkService::setPath(const QString &path)
     resetProperties();
 
     reconnectServiceInterface();
-
-    if (!m_service || !m_service->isValid())
-        return;
-
-    QDBusPendingReply<QVariantMap> reply = m_service->GetProperties();
-    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
-
-    connect(watcher, SIGNAL(finished(QDBusPendingCallWatcher*)),
-            this, SLOT(getPropertiesFinished(QDBusPendingCallWatcher*)));
 }
 
 bool NetworkService::connected()


### PR DESCRIPTION
Explicitly refresh the NetworkService properties after setting up the
PropertyChanged event handlers in the constructor. This ensures
NetworkService D-Bus property changes in connman between the initial
read of properties passed to the NetworkService constructor and the
property changed event handlers being set up are not missed.

Fixes MER#1039 and closes #150.