### PR TITLE
[connman-qt] Fix segfault when flight mode is enabled. Fixes MER#1299

### DIFF
--- a/libconnman-qt/networkmanager.h
+++ b/libconnman-qt/networkmanager.h
@@ -118,9 +118,9 @@ private:
     QHash<QString, NetworkTechnology *> m_technologiesCache;
     QHash<QString, NetworkService *> m_servicesCache;
 
-    /* This is for sorting purpose only, never delete an object from here */
-    QVector<NetworkService *> m_servicesOrder;
-    QVector<NetworkService *> m_savedServicesOrder;
+    /* Define the order of services returned in service lists */
+    QStringList m_servicesOrder;
+    QStringList m_savedServicesOrder;
 
     /* This variable is used just to send signal if changed */
     NetworkService* m_defaultRoute;


### PR DESCRIPTION
Clean up usage of network service cache and services order to prevent
accessing deleted memory. Make m_servicesCache the only place where
NetworkService pointers are stored.

Fix the technologyPathForService() function to return the technology
path not the service path.